### PR TITLE
fix emojis with underscore

### DIFF
--- a/src/components/editor/Form.vue
+++ b/src/components/editor/Form.vue
@@ -73,18 +73,18 @@ export default {
     },
 
     parse(raw) {
+      // parse emojis
+      const emojiConvertor = new Emoji.EmojiConvertor(),
+        textWithEmojis = emojiConvertor.replace_colons(raw);
+
       // parse html
-      const converter = new Showdown.Converter({
+      const mdConverter = new Showdown.Converter({
           simplifiedAutoLink: true,
           tasklists: true,
           tables: true,
           strikethrough: true
         }),
-        parsedHTML = converter.makeHtml(raw);
-
-      // parse emojis
-      const emoji = new Emoji.EmojiConvertor(),
-        htmlWithEmojis = emoji.replace_colons(parsedHTML);
+        htmlWithEmojis = mdConverter.makeHtml(textWithEmojis);
 
       this.$store.dispatch({
         type: "storeHTML",


### PR DESCRIPTION
- inverted the parsing order: first we parse emojis from text; then we parse the HTML from text with emojis

resolves #4 